### PR TITLE
1429: Created a View block to list Recent Conferences

### DIFF
--- a/config/sync/block.block.handlingembeddedvideos.yml
+++ b/config/sync/block.block.handlingembeddedvideos.yml
@@ -2,10 +2,6 @@ uuid: f659967f-83bc-475d-80ce-0a544806919c
 langcode: en
 status: true
 dependencies:
-  content:
-    - 'block_content:videos_block:59bc124a-6070-498e-8d10-ded6d8678539'
-  module:
-    - block_content
   theme:
     - bartik
 id: handlingembeddedvideos

--- a/config/sync/block.block.imageblock.yml
+++ b/config/sync/block.block.imageblock.yml
@@ -2,10 +2,6 @@ uuid: c96edda5-24cd-464d-acff-43f43b65750f
 langcode: en
 status: true
 dependencies:
-  content:
-    - 'block_content:image_block:63d3df11-5381-4738-af8d-b1bba0397538'
-  module:
-    - block_content
   theme:
     - bartik
 id: imageblock

--- a/config/sync/block.block.longtextblock.yml
+++ b/config/sync/block.block.longtextblock.yml
@@ -2,10 +2,6 @@ uuid: 29d119af-08f4-4c10-bb90-159fe6a9ee08
 langcode: en
 status: true
 dependencies:
-  content:
-    - 'block_content:long_text_block:3e5cc8e3-46d4-42b2-8835-5b26f90e43c5'
-  module:
-    - block_content
   theme:
     - bartik
 id: longtextblock

--- a/config/sync/block.block.views_block__recent_conferences_block_1.yml
+++ b/config/sync/block.block.views_block__recent_conferences_block_1.yml
@@ -1,0 +1,30 @@
+uuid: d1288906-e419-49f8-b51f-7476a8abf770
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.recent_conferences
+  module:
+    - system
+    - views
+  theme:
+    - bartik
+id: views_block__recent_conferences_block_1
+theme: bartik
+region: content
+weight: 0
+provider: null
+plugin: 'views_block:recent_conferences-block_1'
+settings:
+  id: 'views_block:recent_conferences-block_1'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+visibility:
+  request_path:
+    id: request_path
+    pages: '<front>'
+    negate: false
+    context_mapping: {  }

--- a/config/sync/core.entity_view_display.node.article.rss.yml
+++ b/config/sync/core.entity_view_display.node.article.rss.yml
@@ -25,4 +25,5 @@ hidden:
   body: true
   comment: true
   field_image: true
+  field_related_conferences: true
   field_tags: true

--- a/config/sync/core.entity_view_display.node.article.teaser.yml
+++ b/config/sync/core.entity_view_display.node.article.teaser.yml
@@ -52,4 +52,5 @@ content:
 hidden:
   comment: true
   field_image: true
+  field_related_conferences: true
   field_tags: true

--- a/config/sync/core.entity_view_display.node.conference.teaser.yml
+++ b/config/sync/core.entity_view_display.node.conference.teaser.yml
@@ -27,4 +27,11 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
-hidden: {  }
+hidden:
+  field_address: true
+  field_banner: true
+  field_contact_email: true
+  field_date: true
+  field_logo: true
+  field_slogan: true
+  field_website: true

--- a/config/sync/core.entity_view_display.node.sponsor.teaser.yml
+++ b/config/sync/core.entity_view_display.node.sponsor.teaser.yml
@@ -27,4 +27,9 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
-hidden: {  }
+hidden:
+  field_about_us: true
+  field_address: true
+  field_contact_email: true
+  field_corporation: true
+  field_sponsor_website: true

--- a/config/sync/views.view.recent_conferences.yml
+++ b/config/sync/views.view.recent_conferences.yml
@@ -1,0 +1,339 @@
+uuid: 2b15f143-1b6f-4efb-b121-35873473efa3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_date
+    - node.type.conference
+  module:
+    - address
+    - datetime
+    - node
+    - user
+id: recent_conferences
+label: 'Recent Conferences'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 5
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: '‹ Previous'
+            next: 'Next ›'
+            first: '« First'
+            last: 'Last »'
+          quantity: 9
+      style:
+        type: default
+      row:
+        type: fields
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_date:
+          id: field_date
+          table: node__field_date
+          field: field_date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: datetime_default
+          settings:
+            timezone_override: ''
+            format_type: html_date
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_address_country_code:
+          id: field_address_country_code
+          table: node__field_address
+          field: field_address_country_code
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          display_name: true
+          plugin_id: country_code
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            conference: conference
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+      sorts:
+        field_date_value:
+          id: field_date_value
+          table: node__field_date
+          field: field_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: day
+          plugin_id: datetime
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          order: DESC
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+      title: 'Recent Conferences'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_date'
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: Block
+    position: 1
+    display_options:
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_date'


### PR DESCRIPTION
I selected Conference title, Address: country_code, and Start Date to display in the Views list. I formatted the display of the date to show the yyyy/mm/dd and not the time. I don't think that changed the Start Date display for the conference content type, only for the display when in the Recent Conferences View list? 
I'm not sure if I correctly limited the block placement to the front page only, as I'm not sure how to view other pages on the site currently (if there are any?).
I also committed "../config/sync/block.block.handlingembeddedvideos.yml" although I'm not sure if that was involved with what I modified today. Please remove it if it's not required and/or would cause problems? I did not commit the "../config/sync/shortcut.set.default.yml".