### PR TITLE
Featuredarticle 1458 kd

### DIFF
--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -5,7 +5,7 @@ slogan: ''
 page:
   403: ''
   404: ''
-  front: /node
+  front: /node/2
 admin_compact_mode: false
 weight_select_max: 100
 langcode: en

--- a/web/themes/custom/tube_theme/css/style.css
+++ b/web/themes/custom/tube_theme/css/style.css
@@ -7825,6 +7825,12 @@ h3, h4, h5, h6 {
   .node-featured-teaser .featured-author {
     color: #222222;
     font-size: 1.125em; }
+  .node-featured-teaser .field__item {
+    float: none; }
+    .node-featured-teaser .field__item img {
+      display: block;
+      margin-left: auto;
+      margin-right: auto; }
 
 h2.featured-title {
   font-size: 2.25em;

--- a/web/themes/custom/tube_theme/css/style.css
+++ b/web/themes/custom/tube_theme/css/style.css
@@ -7819,6 +7819,16 @@ h3, h4, h5, h6 {
 
 .node-featured-teaser {
   background-color: #E0E0E0; }
+  .node-featured-teaser p {
+    color: #000000;
+    font-size: 1.25em; }
+  .node-featured-teaser .featured-author {
+    color: #222222;
+    font-size: 1.125em; }
+
+h2.featured-title {
+  font-size: 2.25em;
+  color: #222222; }
 
 /* GENERAL STYLES
 -------------------------------------------------*/

--- a/web/themes/custom/tube_theme/css/style.css
+++ b/web/themes/custom/tube_theme/css/style.css
@@ -7817,6 +7817,9 @@ h3, h4, h5, h6 {
 .callout-Blue {
   background-color: #0D7DC1; }
 
+.node-featured-teaser {
+  background-color: #E0E0E0; }
+
 /* GENERAL STYLES
 -------------------------------------------------*/
 body {

--- a/web/themes/custom/tube_theme/scss/components/node-featured-teaser.scss
+++ b/web/themes/custom/tube_theme/scss/components/node-featured-teaser.scss
@@ -1,0 +1,3 @@
+.node-featured-teaser {
+	background-color: #E0E0E0;
+}

--- a/web/themes/custom/tube_theme/scss/components/node-featured-teaser.scss
+++ b/web/themes/custom/tube_theme/scss/components/node-featured-teaser.scss
@@ -1,3 +1,16 @@
 .node-featured-teaser {
-	background-color: #E0E0E0;
+	background-color: $featured-background;
+	p {
+		color: #000000;
+		font-size: 1.25em;
+	}
+	.featured-author {
+		color: $black;
+		font-size: 1.125em;
+	}
+}
+
+h2.featured-title {
+	font-size: 2.25em;
+	color: $black;
 }

--- a/web/themes/custom/tube_theme/scss/components/node-featured-teaser.scss
+++ b/web/themes/custom/tube_theme/scss/components/node-featured-teaser.scss
@@ -8,6 +8,14 @@
 		color: $black;
 		font-size: 1.125em;
 	}
+	.field__item {
+		float: none;
+		img {
+			display: block;
+			margin-left: auto;
+			margin-right: auto;	
+		}
+	}
 }
 
 h2.featured-title {

--- a/web/themes/custom/tube_theme/scss/import.scss
+++ b/web/themes/custom/tube_theme/scss/import.scss
@@ -17,3 +17,4 @@
 //Additional scss by Drupal.Tube team
 @import "misc";
 @import "./components/callout-block";
+@import "./components/node-featured-teaser"

--- a/web/themes/custom/tube_theme/scss/variables.scss
+++ b/web/themes/custom/tube_theme/scss/variables.scss
@@ -51,3 +51,7 @@ $green-background: #96BC44;
 $orange-background: #FB8920;
 $blue-background: #0D7DC1;
 $text-and-icon-color: #F6F6F2;
+
+//Colors for Featured nodes (articles and video)
+$featured-background: #E0E0E0;
+

--- a/web/themes/custom/tube_theme/templates/node--article--teaser.html.twig
+++ b/web/themes/custom/tube_theme/templates/node--article--teaser.html.twig
@@ -1,0 +1,1 @@
+{% extends "@tube_theme/template-node-teaser.html.twig" %}

--- a/web/themes/custom/tube_theme/templates/template-node-teaser.html.twig
+++ b/web/themes/custom/tube_theme/templates/template-node-teaser.html.twig
@@ -1,0 +1,108 @@
+{#
+/**
+ * @file
+ * Bootstrap Barrio's theme implementation to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+     Only "getter" methods (method names starting with "get", "has", or "is")
+     and a few common methods such as "id" and "label" are available. Calling
+     other methods (such as node.delete) will result in an exception.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ */
+#}
+{{ attach_library('bootstrap_barrio/node') }}
+
+{%
+  set classes = [
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+    'clearfix',
+    'node-featured-teaser',
+  ]
+%}
+<article{{ attributes.addClass(classes) }}>
+  <header>
+    {{ title_prefix }}
+    {% if not page %}
+      <h2{{ title_attributes.addClass('node__title') }}>
+        <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+      </h2>
+    {% endif %}
+    {{ title_suffix }} 
+  </header>
+  <div{{ content_attributes.addClass('node__content', 'clearfix') }}>
+    {{ content }}
+
+    {% block subtext %}
+      <div class="subtext">
+        {% if display_submitted %}
+        <div class="node__meta">
+          {% block submitted %}
+            <em{{ author_attributes }}>
+              {% trans %}by {{ author_name }}{% endtrans %}
+            </em>
+          {% endblock %}
+          {{ metadata }}
+        </div>
+        {% endif %}
+        <span><strong>{% block subtextheading %}{% endblock %}</strong></span>
+        <span>{% block subtextlvl2 %}{% endblock %}</span>
+        <span>{% block subtextlvl3 %}{% endblock %}</span>
+      </div>
+    {% endblock %}
+    
+  </div>
+</article>

--- a/web/themes/custom/tube_theme/templates/template-node-teaser.html.twig
+++ b/web/themes/custom/tube_theme/templates/template-node-teaser.html.twig
@@ -77,7 +77,7 @@
   <header>
     {{ title_prefix }}
     {% if not page %}
-      <h2{{ title_attributes.addClass('node__title') }}>
+      <h2{{ title_attributes.addClass('node__title', 'featured-title') }}>
         <a href="{{ url }}" rel="bookmark">{{ label }}</a>
       </h2>
     {% endif %}
@@ -91,9 +91,9 @@
         {% if display_submitted %}
         <div class="node__meta">
           {% block submitted %}
-            <em{{ author_attributes }}>
+            <span{{ author_attributes.addClass('featured-author') }}>
               {% trans %}by {{ author_name }}{% endtrans %}
-            </em>
+            </span>
           {% endblock %}
           {{ metadata }}
         </div>


### PR DESCRIPTION
Created a scss file in the /components folder (node-featured-teaser.scss) for the shared styling of the two 'Featured' nodes: background color, font color and size for <p> text, author, and title. 
Added @import line to import.scss file. 
Added a $featured-background color variable to the variables.scss file. 
Did not (yet) do anything with widths/heights, or block display. Image and <p> text still need to be placed on separate lines. 
Did not include the 'Featured Article' title in styling; unsure if should be included in node styling. 