### PR TITLE
Footer 1480 kd

### DIFF
--- a/web/themes/custom/tube_theme/css/style.css
+++ b/web/themes/custom/tube_theme/css/style.css
@@ -7689,16 +7689,6 @@ nav.tabs {
     .show > .btn-outline-dark a.dropdown-toggle:focus {
       box-shadow: 0 0 0 0.2rem rgba(52, 58, 64, 0.5); }
 
-.region-footer-main {
-  justify-content: flex-end; }
-  .region-footer-main .menu--footer .navbar-nav {
-    flex-direction: row;
-    justify-content: flex-end; }
-    .region-footer-main .menu--footer .navbar-nav .nav-item {
-      margin: 10px;
-      text-transform: uppercase;
-      color: #fff; }
-
 .recent {
   background-color: #F6F6F2; }
 
@@ -7845,6 +7835,19 @@ h3, h4, h5, h6 {
 h2.featured-title {
   font-size: 2.25em;
   color: #222222; }
+
+.site-footer .container {
+  display: flex;
+  justify-content: space-around; }
+  .site-footer .container .region-footer-right {
+    justify-content: flex-end; }
+    .site-footer .container .region-footer-right .menu--footer .navbar-nav {
+      flex-direction: row;
+      justify-content: flex-end; }
+      .site-footer .container .region-footer-right .menu--footer .navbar-nav .nav-item {
+        margin: 10px;
+        text-transform: uppercase;
+        color: #fff; }
 
 /* GENERAL STYLES
 -------------------------------------------------*/

--- a/web/themes/custom/tube_theme/css/style.css
+++ b/web/themes/custom/tube_theme/css/style.css
@@ -7689,6 +7689,16 @@ nav.tabs {
     .show > .btn-outline-dark a.dropdown-toggle:focus {
       box-shadow: 0 0 0 0.2rem rgba(52, 58, 64, 0.5); }
 
+.region-footer-main {
+  justify-content: flex-end; }
+  .region-footer-main .menu--footer .navbar-nav {
+    flex-direction: row;
+    justify-content: flex-end; }
+    .region-footer-main .menu--footer .navbar-nav .nav-item {
+      margin: 10px;
+      text-transform: uppercase;
+      color: #fff; }
+
 .recent {
   background-color: #F6F6F2; }
 

--- a/web/themes/custom/tube_theme/scss/components/footer-main.scss
+++ b/web/themes/custom/tube_theme/scss/components/footer-main.scss
@@ -1,0 +1,16 @@
+//Styling for page.html.twig class page.footer_main 
+
+.region-footer-main { 
+  justify-content: flex-end; 
+  .menu--footer {
+    .navbar-nav {
+      flex-direction: row;
+      justify-content: flex-end;
+      .nav-item {
+        margin: 10px;
+        text-transform: uppercase;
+        color: #fff;
+      }
+    }
+  }
+}  

--- a/web/themes/custom/tube_theme/scss/components/footer.scss
+++ b/web/themes/custom/tube_theme/scss/components/footer.scss
@@ -1,0 +1,22 @@
+//Styling for page.html.twig class page.footer_main 
+
+.site-footer {
+  .container {
+    display: flex;
+    justify-content: space-around;
+    .region-footer-right { 
+      justify-content: flex-end; 
+      .menu--footer {
+        .navbar-nav {
+          flex-direction: row;
+          justify-content: flex-end;
+          .nav-item {
+            margin: 10px;
+            text-transform: uppercase;
+            color: #fff;
+          }
+        }
+      }
+    } 
+  }  
+}  

--- a/web/themes/custom/tube_theme/scss/import.scss
+++ b/web/themes/custom/tube_theme/scss/import.scss
@@ -17,5 +17,5 @@
 //Additional scss by Drupal.Tube team
 @import "misc";
 @import "./components/callout-block";
-@import "./components/node-featured-teaser"
-@import "./components/footer-main"
+@import "./components/node-featured-teaser";
+@import "./components/footer";

--- a/web/themes/custom/tube_theme/scss/import.scss
+++ b/web/themes/custom/tube_theme/scss/import.scss
@@ -18,3 +18,4 @@
 @import "misc";
 @import "./components/callout-block";
 @import "./components/node-featured-teaser"
+@import "./components/footer-main"

--- a/web/themes/custom/tube_theme/templates/page.html.twig
+++ b/web/themes/custom/tube_theme/templates/page.html.twig
@@ -1,0 +1,190 @@
+{#
+/**
+ * @file
+ * Bootstrap Barrio's theme implementation to display a single page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template normally located in the
+ * core/modules/system directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ * - logo: The url of the logo image, as defined in theme settings.
+ * - site_name: The name of the site. This is empty when displaying the site
+ *   name has been disabled in the theme settings.
+ * - site_slogan: The slogan of the site. This is empty when displaying the site
+ *   slogan has been disabled in theme settings.
+
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.top_header: Items for the top header region.
+ * - page.top_header_form: Items for the top header form region.
+ * - page.header: Items for the header region.
+ * - page.header_form: Items for the header form region.
+ * - page.highlighted: Items for the highlighted region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.featured_top: Items for the featured top region.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.featured_bottom_first: Items for the first featured bottom region.
+ * - page.featured_bottom_second: Items for the second featured bottom region.
+ * - page.featured_bottom_third: Items for the third featured bottom region.
+ * - page.footer_first: Items for the first footer column.
+ * - page.footer_second: Items for the second footer column.
+ * - page.footer_third: Items for the third footer column.
+ * - page.footer_fourth: Items for the fourth footer column.
+ * - page.footer_fifth: Items for the fifth footer column.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ *
+ * Theme variables:
+ * - navbar_top_attributes: Items for the header region.
+ * - navbar_attributes: Items for the header region.
+ * - content_attributes: Items for the header region.
+ * - sidebar_first_attributes: Items for the highlighted region.
+ * - sidebar_second_attributes: Items for the primary menu region.
+ * - sidebar_collapse: If the sidebar_first will collapse.
+ *
+ * @see template_preprocess_page()
+ * @see bootstrap_barrio_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+<div id="page-wrapper">
+  <div id="page">
+    <header id="header" class="header" role="banner" aria-label="{{ 'Site header'|t}}">
+      {% block head %}
+        {% if page.secondary_menu or page.top_header or page.top_header_form %}
+          <nav{{ navbar_top_attributes }}>
+          {% if container_navbar %}
+          <div class="container">
+          {% endif %}
+              {{ page.secondary_menu }}
+              {{ page.top_header }}
+              {% if page.top_header_form %}
+                <div class="form-inline navbar-form float-right">
+                  {{ page.top_header_form }}
+                </div>
+              {% endif %}
+          {% if container_navbar %}
+          </div>
+          {% endif %}
+          </nav>
+        {% endif %}
+        <nav{{ navbar_attributes }}>
+          {% if container_navbar %}
+          <div class="container">
+          {% endif %}
+            {{ page.header }}
+            {% if page.primary_menu or page.header_form %}
+              <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#CollapsingNavbar" aria-controls="CollapsingNavbar" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
+              <div class="collapse navbar-collapse" id="CollapsingNavbar">
+                {{ page.primary_menu }}
+                {% if page.header_form %}
+                  <div class="form-inline navbar-form float-right">
+                    {{ page.header_form }}
+                  </div>
+                {% endif %}
+	          </div>
+            {% endif %}
+            {% if sidebar_collapse %}
+              <button class="navbar-toggler navbar-toggler-left" type="button" data-toggle="collapse" data-target="#CollapsingLeft" aria-controls="CollapsingLeft" aria-expanded="false" aria-label="Toggle navigation"></button>
+            {% endif %}
+          {% if container_navbar %}
+          </div>
+          {% endif %}
+        </nav>
+      {% endblock %}
+    </header>
+    {% if page.highlighted %}
+      <div class="highlighted">
+        <aside class="{{ container }} section clearfix" role="complementary">
+          {{ page.highlighted }}
+        </aside>
+      </div>
+    {% endif %}
+    {% if page.featured_top %}
+      {% block featured %}
+        <div class="featured-top">
+          <aside class="featured-top__inner section {{ container }} clearfix" role="complementary">
+            {{ page.featured_top }}
+          </aside>
+        </div>
+      {% endblock %}
+    {% endif %}
+    <div id="main-wrapper" class="layout-main-wrapper clearfix">
+      {% block content %}
+        <div id="main" class="{{ container }}">
+          {{ page.breadcrumb }}
+          <div class="row row-offcanvas row-offcanvas-left clearfix">
+              <main{{ content_attributes }}>
+                <section class="section">
+                  <a id="main-content" tabindex="-1"></a>
+                  {{ page.content }}
+                </section>
+              </main>
+            {% if page.sidebar_first %}
+              <div{{ sidebar_first_attributes }}>
+                <aside class="section" role="complementary">
+                  {{ page.sidebar_first }}
+                </aside>
+              </div>
+            {% endif %}
+            {% if page.sidebar_second %}
+              <div{{ sidebar_second_attributes }}>
+                <aside class="section" role="complementary">
+                  {{ page.sidebar_second }}
+                </aside>
+              </div>
+            {% endif %}
+          </div>
+        </div>
+      {% endblock %}
+    </div>
+    {% if page.featured_bottom_first or page.featured_bottom_second or page.featured_bottom_third %}
+      <div class="featured-bottom">
+        <aside class="{{ container }} clearfix" role="complementary">
+          {{ page.featured_bottom_first }}
+          {{ page.featured_bottom_second }}
+          {{ page.featured_bottom_third }}
+        </aside>
+      </div>
+    {% endif %}
+    <footer class="site-footer">
+      {% block footer %}
+        <div class="{{ container }}">
+          {% if page.footer_first or page.footer_second or page.footer_third or page.footer_fourth %}
+            <div class="site-footer__top clearfix">
+              {{ page.footer_first }}
+              {{ page.footer_second }}
+              {{ page.footer_third }}
+              {{ page.footer_fourth }}
+            </div>
+          {% endif %}
+          {% if page.footer_fifth %}
+            <div class="site-footer__bottom">
+              {{ page.footer_fifth }}
+            </div>
+          {% endif %}
+        </div>
+      {% endblock %}
+    </footer>
+  </div>
+</div>

--- a/web/themes/custom/tube_theme/templates/page.html.twig
+++ b/web/themes/custom/tube_theme/templates/page.html.twig
@@ -170,11 +170,11 @@
     <footer class="site-footer">
       {% block footer %}
         <div class="{{ container }}">
-          {% if page.footer_first or page.footer_second or page.footer_third %}
+          {% if page.footer_left or page.footer_center or page.footer_right %}
             <div class="site-footer__top clearfix">
-              {{ page.footer_first }}
-              {{ page.footer_second }}
-              {{ page.footer_third }}
+              {{ page.footer_left }}
+              {{ page.footer_center }}
+              {{ page.footer_right }}
             </div>
           {% endif %}
         </div>

--- a/web/themes/custom/tube_theme/templates/page.html.twig
+++ b/web/themes/custom/tube_theme/templates/page.html.twig
@@ -170,17 +170,11 @@
     <footer class="site-footer">
       {% block footer %}
         <div class="{{ container }}">
-          {% if page.footer_first or page.footer_second or page.footer_third or page.footer_fourth %}
+          {% if page.footer_first or page.footer_second or page.footer_third %}
             <div class="site-footer__top clearfix">
               {{ page.footer_first }}
               {{ page.footer_second }}
               {{ page.footer_third }}
-              {{ page.footer_fourth }}
-            </div>
-          {% endif %}
-          {% if page.footer_fifth %}
-            <div class="site-footer__bottom">
-              {{ page.footer_fifth }}
             </div>
           {% endif %}
         </div>

--- a/web/themes/custom/tube_theme/templates/page.html.twig
+++ b/web/themes/custom/tube_theme/templates/page.html.twig
@@ -170,12 +170,8 @@
     <footer class="site-footer">
       {% block footer %}
         <div class="{{ container }}">
-          {% if page.footer_left or page.footer_center or page.footer_right %}
-            <div class="site-footer__top clearfix">
-              {{ page.footer_left }}
-              {{ page.footer_center }}
-              {{ page.footer_right }}
-            </div>
+          {% if page.footer_main %}
+              {{ page.footer_main }}
           {% endif %}
         </div>
       {% endblock %}

--- a/web/themes/custom/tube_theme/templates/page.html.twig
+++ b/web/themes/custom/tube_theme/templates/page.html.twig
@@ -170,8 +170,10 @@
     <footer class="site-footer">
       {% block footer %}
         <div class="{{ container }}">
-          {% if page.footer_main %}
-              {{ page.footer_main }}
+          {% if page.footer_left or page.footer_center or page.footer_right %}
+              {{ page.footer_left }}
+              {{ page.footer_center }}
+              {{ page.footer_right }}
           {% endif %}
         </div>
       {% endblock %}

--- a/web/themes/custom/tube_theme/tube_theme.info.yml
+++ b/web/themes/custom/tube_theme/tube_theme.info.yml
@@ -31,8 +31,7 @@ regions:
   footer_first: 'Footer first'
   footer_second: 'Footer second'
   footer_third: 'Footer third'
-  footer_fourth: 'Footer fourth'
-  footer_fifth: 'Footer fifth'
+  
 
 # Information added by Drupal.org packaging script on 2018-08-12
 version: '8.x-1.6'

--- a/web/themes/custom/tube_theme/tube_theme.info.yml
+++ b/web/themes/custom/tube_theme/tube_theme.info.yml
@@ -28,9 +28,9 @@ regions:
   featured_bottom_first: 'Featured bottom first'
   featured_bottom_second: 'Featured bottom second'
   featured_bottom_third: 'Featured bottom third'
-  footer_first: 'Footer first'
-  footer_second: 'Footer second'
-  footer_third: 'Footer third'
+  footer_left: 'Footer left'
+  footer_center: 'Footer center'
+  footer_right: 'Footer right'
   
 
 # Information added by Drupal.org packaging script on 2018-08-12

--- a/web/themes/custom/tube_theme/tube_theme.info.yml
+++ b/web/themes/custom/tube_theme/tube_theme.info.yml
@@ -28,9 +28,7 @@ regions:
   featured_bottom_first: 'Featured bottom first'
   featured_bottom_second: 'Featured bottom second'
   featured_bottom_third: 'Featured bottom third'
-  footer_left: 'Footer left'
-  footer_center: 'Footer center'
-  footer_right: 'Footer right'
+  footer_main: 'Footer main'
   
 
 # Information added by Drupal.org packaging script on 2018-08-12

--- a/web/themes/custom/tube_theme/tube_theme.info.yml
+++ b/web/themes/custom/tube_theme/tube_theme.info.yml
@@ -28,7 +28,9 @@ regions:
   featured_bottom_first: 'Featured bottom first'
   featured_bottom_second: 'Featured bottom second'
   featured_bottom_third: 'Featured bottom third'
-  footer_main: 'Footer main'
+  footer_left: 'Footer left'
+  footer_center: 'Footer center'
+  footer_right: 'Footer right'
   
 
 # Information added by Drupal.org packaging script on 2018-08-12


### PR DESCRIPTION
Initially created three footer regions, but after experimenting with placing blocks via the UI I found that enabling the existing Footer Menu and placing it in a footer region (via Structure--Block Layout) allowed me to add links (Structure--Menus--Footer--Add link) for the 'About', 'Get Involved', and 'Privacy' menu items based on the site design, that I could then style with one scss file. 
So I ultimately only created one footer region named footer-main, and then went ahead and created and saved a footer-main.scss file in the Components folder. I tested out enabling the Footer Menu with the three links again and it worked for me, so hopefully that can be recreated. 
If there was another reason for having three separate regions instead of just space for three links in a footer menu, I can easily add the two additional regions back in and adapt the styling.