### PR TITLE
Dconsole 1504 kt

### DIFF
--- a/web/modules/custom/dynamic_copyright_block/dynamic_copyright_block.info.yml
+++ b/web/modules/custom/dynamic_copyright_block/dynamic_copyright_block.info.yml
@@ -1,0 +1,5 @@
+name: 'Dynamic Copyright Block'
+type: module
+description: 'Allows you to generate dynamic copyright blocks'
+core: 8.x
+package: 'Custom'

--- a/web/modules/custom/dynamic_copyright_block/dynamic_copyright_block.module
+++ b/web/modules/custom/dynamic_copyright_block/dynamic_copyright_block.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Contains dynamic_copyright_block.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function dynamic_copyright_block_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the dynamic_copyright_block module.
+    case 'help.page.dynamic_copyright_block':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Allows you to generate dynamic copyright blocks') . '</p>';
+      return $output;
+
+    default:
+  }
+}

--- a/web/modules/custom/dynamic_copyright_block/src/Plugin/Block/Dynamiccopyrightblock.php
+++ b/web/modules/custom/dynamic_copyright_block/src/Plugin/Block/Dynamiccopyrightblock.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\dynamic_copyright_block\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides a 'Dynamiccopyrightblock' block.
+ *
+ * @Block(
+ *  id = "dynamiccopyrightblock",
+ *  admin_label = @Translation("Dynamiccopyrightblock"),
+ * )
+ */
+class Dynamiccopyrightblock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+            'copyright_text_prefix' => 'Copyright ©',
+          ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+    $form['copyright_text_prefix'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Copyright text prefix'),
+    '#description' => $this->t('Text before the copyright year.'),
+      '#default_value' => $this->configuration['copyright_text_prefix'],
+      '#maxlength' => 64,
+      '#size' => 64,
+      '#weight' => '0',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    $this->configuration['copyright_text_prefix'] = $form_state->getValue('copyright_text_prefix');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $build = [];
+    $build['dynamiccopyrightblock_copyright_text_prefix']['#markup'] = '<p>' . $this->configuration['copyright_text_prefix'] . '</p>';
+
+    return $build;
+  }
+
+}

--- a/web/modules/custom/dynamic_copyright_block/src/Plugin/Block/Dynamiccopyrightblock.php
+++ b/web/modules/custom/dynamic_copyright_block/src/Plugin/Block/Dynamiccopyrightblock.php
@@ -6,14 +6,14 @@ use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
- * Provides a 'Dynamiccopyrightblock' block.
+ * Provides a 'DynamicCopyrightBlock' block.
  *
  * @Block(
- *  id = "dynamiccopyrightblock",
- *  admin_label = @Translation("Dynamiccopyrightblock"),
+ *  id = "dynamic_copyright_block",
+ *  admin_label = @Translation("Dynamic copyright block"),
  * )
  */
-class Dynamiccopyrightblock extends BlockBase {
+class DynamicCopyrightBlock extends BlockBase {
 
   /**
    * {@inheritdoc}
@@ -31,11 +31,36 @@ class Dynamiccopyrightblock extends BlockBase {
     $form['copyright_text_prefix'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Copyright text prefix'),
-    '#description' => $this->t('Text before the copyright year.'),
+    '#description' => $this->t('Text before the copyright year'),
       '#default_value' => $this->configuration['copyright_text_prefix'],
       '#maxlength' => 64,
       '#size' => 64,
-      '#weight' => '0',
+      '#weight' => '4',
+    ];
+    $form['copyright_year'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Copyright year'),
+      '#description' => $this->t('Copyright year. Leave blank for current year.'),
+      '#default_value' => $this->configuration['copyright_year'],
+      '#maxlength' => 12,
+      '#size' => 12,
+      '#weight' => '5',
+    ];
+    $form['copyright_text_suffix'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Copyright text suffix'),
+    '#description' => $this->t('Text after the copyright year'),
+      '#default_value' => $this->configuration['copyright_text_suffix'],
+      '#maxlength' => 64,
+      '#size' => 64,
+      '#weight' => '6',
+    ];
+    $form['copyright_color'] = [
+      '#type' => 'color',
+      '#title' => $this
+        ->t('Copyright text color'),
+      '#default_value' => $this->configuration['copyright_color'],
+      '#weight' => '7',
     ];
 
     return $form;
@@ -46,6 +71,9 @@ class Dynamiccopyrightblock extends BlockBase {
    */
   public function blockSubmit($form, FormStateInterface $form_state) {
     $this->configuration['copyright_text_prefix'] = $form_state->getValue('copyright_text_prefix');
+    $this->configuration['copyright_year'] = $form_state->getValue('copyright_year');
+    $this->configuration['copyright_text_suffix'] = $form_state->getValue('copyright_text_suffix');
+    $this->configuration['copyright_color'] = $form_state->getValue('copyright_color');
   }
 
   /**
@@ -53,7 +81,18 @@ class Dynamiccopyrightblock extends BlockBase {
    */
   public function build() {
     $build = [];
-    $build['dynamiccopyrightblock_copyright_text_prefix']['#markup'] = '<p>' . $this->configuration['copyright_text_prefix'] . '</p>';
+
+    $prefix = $this->configuration['copyright_text_prefix'];
+    if (empty($this->configuration['copyright_year'])) {
+      $year = date('Y');
+    }
+    else {
+      $year = $this->configuration['copyright_year'];
+    }
+    $suffix = $this->configuration['copyright_text_suffix'];
+    $color = $this->configuration['copyright_color'];
+
+    $build['dc_block']['#markup'] = "<p>{$prefix}{$year}{$suffix}</p>";
 
     return $build;
   }

--- a/web/modules/custom/dynamic_copyright_block/src/Plugin/Block/Dynamiccopyrightblock.php
+++ b/web/modules/custom/dynamic_copyright_block/src/Plugin/Block/Dynamiccopyrightblock.php
@@ -92,7 +92,7 @@ class DynamicCopyrightBlock extends BlockBase {
     $suffix = $this->configuration['copyright_text_suffix'];
     $color = $this->configuration['copyright_color'];
 
-    $build['dc_block']['#markup'] = "<p>{$prefix}{$year}{$suffix}</p>";
+    $build['dc_block']['#markup'] = "<p>{$prefix} {$year} {$suffix}</p>";
 
     return $build;
   }


### PR DESCRIPTION
I edited the last line in the above file like this $build['dc_block']['#markup'] = "<p>{$prefix}{$year}&nbsp{$suffix}</p>" to print out something like this
Copyright© 2018 Debug Academy (adding space between the year and the suffix. That didn't work as &nbsp was printed as it is enclosed in the <p></p> tag. So I removed the &nbsp added space manually (pressed the spacebar), that didn't work either and printed this:  This block is broken or missing. You may be missing content or you might need to enable the original module. Removing the space and restoring the line to the way it was didn't fix the problem either