### PR TITLE
Mapdisplay 1523 kt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,9 @@
             },
             "drupal/core": {
                 "Allow alternate default moderation states": "https://www.drupal.org/files/issues/2018-09-21/2856967-54.patch"
+            },
+            "drupal/geolocation_address_link": {
+                "Geolocation Address Link issue 2975883": "https://www.drupal.org/files/issues/2018-05-29/array-change-2975883-9.patch"
             }
         },
         "patchLevel": {

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "drupal/core": "^8.6.0",
         "drupal/facets": "^1.2",
         "drupal/fontawesome": "^2.9",
+        "drupal/geolocation": "^1.11",
         "drupal/pathauto": "^1.0",
         "drupal/recaptcha": "^2.3",
         "drupal/search_api": "^1.11",

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "drupal/facets": "^1.2",
         "drupal/fontawesome": "^2.9",
         "drupal/geolocation": "^1.11",
+        "drupal/geolocation_address_link": "^1.1",
         "drupal/pathauto": "^1.0",
         "drupal/recaptcha": "^2.3",
         "drupal/search_api": "^1.11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "892f1595a75d24e7bec0a9a4f669472d",
+    "content-hash": "d1e1b4b86864ec44e7fb92a2ee8453a7",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2850,6 +2850,55 @@
             "homepage": "https://www.drupal.org/project/geolocation",
             "support": {
                 "source": "http://cgit.drupalcode.org/geolocation"
+            }
+        },
+        {
+            "name": "drupal/geolocation_address_link",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/geolocation_address_link",
+                "reference": "8.x-1.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/geolocation_address_link-8.x-1.1.zip",
+                "reference": "8.x-1.1",
+                "shasum": "3854f1a6aae7584b8eb06504fa2fe84ab6db3cc0"
+            },
+            "require": {
+                "drupal/address": "*",
+                "drupal/core": "~8.0",
+                "drupal/geolocation": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.1",
+                    "datestamp": "1513955284",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "KarenS",
+                    "homepage": "https://www.drupal.org/user/45874"
+                }
+            ],
+            "description": "Update Geolocation fields from Address fields.",
+            "homepage": "https://www.drupal.org/project/geolocation_address_link",
+            "support": {
+                "source": "http://cgit.drupalcode.org/geolocation_address_link"
             }
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "864e6a96af50ac2e0776a8a86345705b",
+    "content-hash": "892f1595a75d24e7bec0a9a4f669472d",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2799,6 +2799,57 @@
             "homepage": "https://www.drupal.org/project/fontawesome",
             "support": {
                 "source": "http://cgit.drupalcode.org/fontawesome"
+            }
+        },
+        {
+            "name": "drupal/geolocation",
+            "version": "1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/geolocation",
+                "reference": "8.x-1.11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/geolocation-8.x-1.11.zip",
+                "reference": "8.x-1.11",
+                "shasum": "a401d5c576a8c4886e84272f2ca2a3c524c46869"
+            },
+            "require": {
+                "drupal/core": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.11",
+                    "datestamp": "1505687043",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "ChristianAdamski",
+                    "homepage": "https://www.drupal.org/user/867880"
+                },
+                {
+                    "name": "derjochenmeyer",
+                    "homepage": "https://www.drupal.org/user/106134"
+                }
+            ],
+            "description": "Provides a simple geolocation Drupal field type to store and display location data (lat, lng).",
+            "homepage": "https://www.drupal.org/project/geolocation",
+            "support": {
+                "source": "http://cgit.drupalcode.org/geolocation"
             }
         },
         {
@@ -9050,11 +9101,6 @@
         {
             "name": "webflo/drupal-core-require-dev",
             "version": "8.6.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webflo/drupal-core-require-dev.git",
-                "reference": "3fa727e875f73906f7e9325619b540f7012876ee"
-            },
             "require": {
                 "behat/mink": "1.7.x-dev",
                 "behat/mink-goutte-driver": "^1.2",

--- a/config/sync/core.entity_form_display.node.conference.default.yml
+++ b/config/sync/core.entity_form_display.node.conference.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.conference.body
     - field.field.node.conference.field_address
+    - field.field.node.conference.field_address_map
     - field.field.node.conference.field_contact_email
     - field.field.node.conference.field_date
     - field.field.node.conference.field_event_name
@@ -16,11 +17,11 @@ dependencies:
     - field.field.node.conference.field_website
     - image.style.thumbnail
     - node.type.conference
-    - workflows.workflow.editorial
   module:
     - address
     - content_moderation
     - datetime
+    - geolocation
     - image
     - link
     - path
@@ -51,6 +52,41 @@ content:
       default_country: null
     third_party_settings: {  }
     type: address_default
+    region: content
+  field_address_map:
+    weight: 133
+    settings:
+      default_longitude: ''
+      default_latitude: ''
+      target_address_field: field_address
+      google_map_settings:
+        height: 217px
+        width: 504px
+        type: ROADMAP
+        zoom: '2'
+        maxZoom: 18
+        minZoom: 0
+        mapTypeControl: 1
+        streetViewControl: 1
+        zoomControl: 1
+        scrollwheel: 1
+        gestureHandling: auto
+        draggable: 1
+        style: ''
+        info_auto_display: 1
+        marker_icon_path: ''
+        disableAutoPan: 1
+        rotateControl: 0
+        fullscreenControl: 0
+        preferScrollingToZooming: 0
+        disableDoubleClickZoom: 0
+      auto_client_location: '0'
+      auto_client_location_marker: '0'
+      populate_address_field: '0'
+      explicite_actions_address_field: '0'
+      allow_override_map_settings: 0
+    third_party_settings: {  }
+    type: geolocation_googlegeocoder
     region: content
   field_contact_email:
     weight: 128

--- a/config/sync/core.entity_view_display.node.conference.default.yml
+++ b/config/sync/core.entity_view_display.node.conference.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.base_field_override.node.conference.title
     - field.field.node.conference.body
     - field.field.node.conference.field_address
+    - field.field.node.conference.field_address_map
     - field.field.node.conference.field_contact_email
     - field.field.node.conference.field_date
     - field.field.node.conference.field_event_name
@@ -21,6 +22,7 @@ dependencies:
     - address
     - datetime
     - drupal_tube_layouts
+    - geolocation
     - image
     - layout_builder
     - layout_discovery
@@ -146,6 +148,21 @@ third_party_settings:
                 entity: layout_builder.entity
             additional: {  }
             weight: 8
+          da2ac43f-6c00-4ab5-97c2-62f2cf1f5180:
+            uuid: da2ac43f-6c00-4ab5-97c2-62f2cf1f5180
+            region: content
+            configuration:
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              id: 'field_block:node:conference:field_address_map'
+              formatter:
+                label: above
+                settings: {  }
+                third_party_settings: {  }
+                type: geolocation_latlng
+            additional: {  }
+            weight: 9
       -
         layout_id: layout_onecol
         layout_settings: {  }
@@ -322,6 +339,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: address_default
+    region: content
+  field_address_map:
+    weight: 12
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: geolocation_latlng
     region: content
   field_contact_email:
     weight: 8

--- a/config/sync/core.entity_view_display.node.conference.teaser.yml
+++ b/config/sync/core.entity_view_display.node.conference.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.conference.body
     - field.field.node.conference.field_address
+    - field.field.node.conference.field_address_map
     - field.field.node.conference.field_contact_email
     - field.field.node.conference.field_date
     - field.field.node.conference.field_event_name
@@ -35,6 +36,11 @@ content:
       trim_length: 600
     third_party_settings: {  }
     region: content
+  content_moderation_control:
+    weight: -20
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_date:
     type: datetime_default
     weight: 3
@@ -60,6 +66,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_address: true
+  field_address_map: true
   field_contact_email: true
   field_event_name: true
   field_event_type: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -27,6 +27,8 @@ module:
   file: 0
   filter: 0
   fontawesome: 0
+  geolocation: 0
+  geolocation_address_link: 0
   help: 0
   history: 0
   image: 0

--- a/config/sync/field.field.node.conference.field_address_map.yml
+++ b/config/sync/field.field.node.conference.field_address_map.yml
@@ -1,0 +1,21 @@
+uuid: e882694c-2299-4bbd-b8c8-24a0f6e3c13e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_address_map
+    - node.type.conference
+  module:
+    - geolocation
+id: node.conference.field_address_map
+field_name: field_address_map
+entity_type: node
+bundle: conference
+label: 'Address Map'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: geolocation

--- a/config/sync/field.storage.node.field_address_map.yml
+++ b/config/sync/field.storage.node.field_address_map.yml
@@ -1,0 +1,19 @@
+uuid: f7069694-a119-4cbc-8591-8b4da6dc34e0
+langcode: en
+status: true
+dependencies:
+  module:
+    - geolocation
+    - node
+id: node.field_address_map
+field_name: field_address_map
+entity_type: node
+type: geolocation
+settings: {  }
+module: geolocation
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/geolocation.settings.yml
+++ b/config/sync/geolocation.settings.yml
@@ -1,0 +1,4 @@
+google_map_api_key: ''
+google_map_custom_url_parameters: {  }
+_core:
+  default_config_hash: wNpilbhustdj8tLBsYJ6GPdxS5lUKU5rRei_XxSyd3A


### PR DESCRIPTION
I am submitting a this pull request for assistance with resolving the issue of not being able to display a map of the conference location. Here are the steps I followed:

1. Installed and enabled the Geolocation and Geolocation_Address_Link modules, and patched the geolocation_address_link as I was facing this issue: https://www.drupal.org/project/geolocation_address_link/issues/2975883
2- Created Address Map (Geolocation) field in Conference CT.
3. Created a conference node following this tutorial partially (https://www.ostraining.com/blog/drupal/display-map-markers-in-drupal-8-with-geolocation-module/). Map didn't display.
4. Added an API key for google maps. Map didn't display. Removed the API key
5. Setup a completely separate drupal test site and installed the Geolocation module in addition to the Geocoder, Geocoder_field and Geocoder_address modules and followed the instructions here (https://www.drupal.org/docs/8/modules/geolocation-field/configuring-integration-between-geolocation-and-address-field). The Geocoding results from Address field. Map didn't display with or without an API key.
6. Did some research and stumbled upon this old post (https://developers.google.com/web/updates/2016/04/geolocation-on-secure-contexts-only). Not sure how much it applies to my issue.

What worked:
1. On a separate Drupal test site, downloaded and installed the Simple Google Maps module, and followed this https://www.youtube.com/watch?v=FVvKJlq4Wo8
2. The map displays without API key, but the address needs to be keyed in manually.

Any suggestions?!
